### PR TITLE
Moving branch configuration to the JPS from script

### DIFF
--- a/add-git-project.cs
+++ b/add-git-project.cs
@@ -7,7 +7,7 @@ var params = {
    type: "git",
    project: "ROOT",
    url: url,
-   branch: "master",
+   branch: branch,
    keyId: "WILL BE AUTODETECTED BELLOW",
    login: login,
    password: password,

--- a/manifest.jps
+++ b/manifest.jps
@@ -26,6 +26,7 @@
             "script": "https://raw.githubusercontent.com/jelastic-jps/git-push-deploy/master/add-git-project.cs",
             "params": {
               "url": "github.com:jelastic-jps/test-private-repo.git",
+              "branch": "master",
               "login": "git",
               "password": null
             },


### PR DESCRIPTION
Looks like JPS is more logical place to keep target branch for CI